### PR TITLE
Set addrlen to sockaddr_in size in accept call

### DIFF
--- a/move/conn.c
+++ b/move/conn.c
@@ -307,7 +307,7 @@ PUBLIC int conn_resume_readline(VECTOR args) {
 PUBLIC int conn_resume_accept(OVECTOR server) {
   int fd;
   struct sockaddr_in addr;
-  socklen_t addrlen;
+  socklen_t addrlen = sizeof(addr);
 
   fd = NUM(AT(server, CO_HANDLE));
   fd = accept(fd, (struct sockaddr *) &addr, &addrlen);


### PR DESCRIPTION
The `addrlen` argument in the call to `accept` is not initialized. This results in spurious failures of `accept` when it is negative. I see this on my system by performing these steps:
1. Start move with a default database created with the build script
2. login as Wizard and build two guest accounts.
3. While logged in as wizard, log in in another terminal as the first guest.
4. While both of the above are logged in try to connect again (I used netcat) to log in as the second guest.

On step 4 the connection fails immediately and the thread performing the `accept` dies with EINVAL. With the fix in this pull request step 4 works fine.
